### PR TITLE
Change iOS deployment target to iOS 11 (Xcode 14.3 minimum)

### DIFF
--- a/Examples/ReactionsExample.xcodeproj/project.pbxproj
+++ b/Examples/ReactionsExample.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Reactions/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yannickloriot.Reactions;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -670,7 +670,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Reactions/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yannickloriot.Reactions;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Requirements
 
-- iOS 8.0+
+- iOS 11.0+
 - Xcode 9.0+
 - Swift 4.2+
 


### PR DESCRIPTION
Fix for Xcode 14.3 that needs at least iOS 11 as deployment target.